### PR TITLE
Instrument with WIPAC Telemetry Prototype

### DIFF
--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -66,17 +66,21 @@ class Message:
         neither is the `headers` field.
         """
         return (
-            bool(other)
-            and isinstance(other, Message)
-            and self.deserialize_data() == other.deserialize_data()
+            bool(other) and isinstance(other, Message) and self.data() == other.data()
         )
 
-    def deserialize_data(self) -> Any:
+    @property
+    def data(self) -> Any:
         """Read and return an object from the `data` field."""
         return pickle.loads(self.payload)["data"]
 
-    @staticmethod  # TODO: rename to just `serialize()`
-    def serialize_data(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
+    @property
+    def headers(self) -> Any:
+        """Read and return dict from the `headers` field."""
+        return pickle.loads(self.payload)["headers"]
+
+    @staticmethod
+    def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
         """Return serialized representation of message payload as a bytes object.
 
         Optionally include `headers` dict for internal information.

--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -83,6 +83,9 @@ class Message:
 
         Optionally include `headers` dict for internal information.
         """
+        if not headers:
+            headers = {}
+
         return pickle.dumps({"headers": headers, "data": data}, protocol=4)
 
 

--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -66,21 +66,17 @@ class Message:
         neither is the `headers` field.
         """
         return (
-            bool(other) and isinstance(other, Message) and self.data() == other.data()
+            bool(other)
+            and isinstance(other, Message)
+            and self.deserialize_data() == other.deserialize_data()
         )
 
-    @property
-    def data(self) -> Any:
+    def deserialize_data(self) -> Any:
         """Read and return an object from the `data` field."""
         return pickle.loads(self.payload)["data"]
 
-    @property
-    def headers(self) -> Any:
-        """Read and return dict from the `headers` field."""
-        return pickle.loads(self.payload)["headers"]
-
-    @staticmethod
-    def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
+    @staticmethod  # TODO: rename to just `serialize()`
+    def serialize_data(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
         """Return serialized representation of message payload as a bytes object.
 
         Optionally include `headers` dict for internal information.

--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -65,18 +65,20 @@ class Message:
         `msg_id` is not a reliable source for testing equality. And
         neither is the `headers` field.
         """
-        return (
-            bool(other)
-            and isinstance(other, Message)
-            and self.deserialize_data() == other.deserialize_data()
-        )
+        return bool(other) and isinstance(other, Message) and (self.data == other.data)
 
-    def deserialize_data(self) -> Any:
+    @property
+    def data(self) -> Any:
         """Read and return an object from the `data` field."""
         return pickle.loads(self.payload)["data"]
 
-    @staticmethod  # TODO: rename to just `serialize()`
-    def serialize_data(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
+    @property
+    def headers(self) -> Any:
+        """Read and return dict from the `headers` field."""
+        return pickle.loads(self.payload)["headers"]
+
+    @staticmethod
+    def serialize(data: Any, headers: Optional[Dict[str, Any]] = None) -> bytes:
         """Return serialized representation of message payload as a bytes object.
 
         Optionally include `headers` dict for internal information.

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -279,7 +279,9 @@ class MessageGeneratorContext:
             timeout=queue.timeout, propagate_error=(not queue.except_errors)
         )
         self.queue = queue
+
         self._span: Optional[wtt.Span] = None
+        self._span_carrier: Optional[Dict[str, Any]] = None
 
         self.entered = False
         self.msg: Optional[Message] = None
@@ -305,9 +307,10 @@ class MessageGeneratorContext:
             raise RuntimeError(
                 "A 'MessageGeneratorContext' instance cannot be re-entered."
             )
-
         self.entered = True
+
         self._span = wtt.get_current_span()
+        self._span_carrier = wtt.inject_span_carrier()
 
         return self
 
@@ -388,7 +391,7 @@ class MessageGeneratorContext:
             "self.queue._prefetch",
             "self.queue.timeout",
         ],
-        carrier="self._span",
+        carrier="self._span_carrier",
     )
     def __next__(self) -> Any:
         """Return next Message in queue."""

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -233,17 +233,12 @@ class Queue:
             carrier_relation=wtt.CarrierRelation.LINK,
         )
         def get_message_callback(msg: Message) -> Message:
+            if not msg:
+                raise Exception("No message available")
             return msg
 
         sub = self._create_sub_queue()
-        msg = sub.get_message(self.timeout * 1000)
-        get_message_callback(msg)
-
-        if not msg:
-            raise Exception("No message available")
-
-        if msg.headers:
-            wtt.get_current_span().add_link(wtt.extract_links_carrier(msg.headers))
+        msg = get_message_callback(sub.get_message(self.timeout * 1000))
 
         data = msg.data
         try:

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -4,7 +4,7 @@ import contextlib
 import logging
 import types
 import uuid
-from typing import Any, Generator, Optional, Type
+from typing import Any, Dict, Generator, Optional, Type
 
 import wipac_telemetry.tracing_tools as wtt
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -198,7 +198,7 @@ class Queue:
         logging.debug("Creating new MessageGeneratorContext instance.")
         return MessageGeneratorContext(self._create_sub_queue(), self)
 
-    @contextlib.contextmanager
+    @contextlib.contextmanager  # needs to wrap @wtt stuff to span children correctly
     @wtt.spanned(
         these=[
             "self._backend_name",
@@ -207,7 +207,7 @@ class Queue:
             "self._prefetch",
             "self.timeout",
         ]
-    )  # FIXME: child spans are not inheriting "parent_id"
+    )
     def recv_one(self) -> Generator[Any, None, None]:
         """Receive one message from the queue.
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -235,6 +235,9 @@ class Queue:
         if not msg:
             raise Exception("No message available")
 
+        if msg.headers:
+            wtt.get_current_span().add_link(wtt.extract_links_carrier(msg.headers))
+
         data = msg.data
         try:
             yield data

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -121,7 +121,7 @@ class Queue:
         """
         # TODO - add carrier! what about adding a `msg.headers` attr?
         # msg = Message.serialize_data(data, headers=wtt.inject_links_carrier())
-        msg = Message.serialize(data)
+        msg = Message.serialize_data(data)
         self.raw_pub_queue.send_message(msg)
 
     @wtt.spanned(
@@ -246,7 +246,7 @@ class Queue:
         if not msg:
             raise Exception("No message available")
 
-        data = msg.data()
+        data = msg.deserialize_data()
         try:
             yield data
         except Exception:  # pylint:disable=broad-except
@@ -421,4 +421,4 @@ class MessageGeneratorContext:
                 "Yielded value is `None`. This should not have happened."
             )
 
-        return self.msg.data()
+        return self.msg.deserialize_data()

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -120,8 +120,8 @@ class Queue:
             data (Any): object of data to send (must be picklable)
         """
         # TODO - add carrier! what about adding a `msg.headers` attr?
-        # msg = Message.serialize_data(data, headers=wtt.inject_links_carrier())
-        msg = Message.serialize_data(data)
+        # msg = Message.serialize(data, headers=wtt.inject_links_carrier())
+        msg = Message.serialize(data)
         self.raw_pub_queue.send_message(msg)
 
     @wtt.spanned(
@@ -246,7 +246,7 @@ class Queue:
         if not msg:
             raise Exception("No message available")
 
-        data = msg.deserialize_data()
+        data = msg.data
         try:
             yield data
         except Exception:  # pylint:disable=broad-except
@@ -421,4 +421,4 @@ class MessageGeneratorContext:
                 "Yielded value is `None`. This should not have happened."
             )
 
-        return self.msg.deserialize_data()
+        return self.msg.data

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -290,8 +290,6 @@ class MessageGeneratorContext:
         self._span_parent_carrier = _span_parent_carrier
         self._span: Optional[wtt.Span] = None
 
-        self.i = 0
-
         self.entered = False
         self.msg: Optional[Message] = None
 
@@ -395,7 +393,6 @@ class MessageGeneratorContext:
 
     @wtt.spanned(
         # TODO - add link/parent as `self._span`
-        these=["self.i"],
         kind=wtt.SpanKind.CONSUMER,
         # carrier="properties.headers",  # TODO: figure how to get carrier
         carrier_relation=wtt.CarrierRelation.LINK,
@@ -422,5 +419,4 @@ class MessageGeneratorContext:
                 "Yielded value is `None`. This should not have happened."
             )
 
-        self.i += 1
         return self.msg.deserialize_data()

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -198,6 +198,7 @@ class Queue:
         logging.debug("Creating new MessageGeneratorContext instance.")
         return MessageGeneratorContext(self._create_sub_queue(), self)
 
+    @contextlib.contextmanager
     @wtt.spanned(
         these=[
             "self._backend_name",
@@ -207,7 +208,6 @@ class Queue:
             "self.timeout",
         ]
     )  # FIXME: child spans are not inheriting "parent_id"
-    @contextlib.contextmanager
     def recv_one(self) -> Generator[Any, None, None]:
         """Receive one message from the queue.
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -120,7 +120,9 @@ class Queue:
             data (Any): object of data to send (must be picklable)
         """
         # TODO - add carrier! what about adding a `msg.headers` attr?
-        self.raw_pub_queue.send_message(Message.serialize_data(data))
+        # msg = Message.serialize_data(data, headers=wtt.inject_links_carrier())
+        msg = Message.serialize_data(data)
+        self.raw_pub_queue.send_message(msg)
 
     @wtt.spanned(
         these=[

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -117,11 +117,9 @@ class Queue:
         """Send a message to the queue.
 
         Arguments:
-            data (Any): object of data to send (must be picklable)
+            data (Any): object of data to send (must be serializable)
         """
-        # TODO - add carrier! what about adding a `msg.headers` attr?
-        # msg = Message.serialize(data, headers=wtt.inject_links_carrier())
-        msg = Message.serialize(data)
+        msg = Message.serialize(data, headers=wtt.inject_links_carrier())
         self.raw_pub_queue.send_message(msg)
 
     @wtt.spanned(

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -110,6 +110,7 @@ class Queue:
             "self._name",
             "self._prefetch",
             "self.timeout",
+            # TODO - add carrier! what about adding `msg.headers`?
         ],
         kind=wtt.SpanKind.PRODUCER,
     )
@@ -287,6 +288,16 @@ class MessageGeneratorContext:
         self.entered = False
         self.msg: Optional[Message] = None
 
+    @wtt.spanned(  # TODO: better as an event?
+        these=[
+            "self.queue._backend_name",
+            "self.queue._address",
+            "self.queue._name",
+            "self.queue._prefetch",
+            "self.queue.timeout",
+        ],
+        kind=wtt.SpanKind.CONSUMER,
+    )
     def __enter__(self) -> "MessageGeneratorContext":
         """Return instance.
 
@@ -302,7 +313,17 @@ class MessageGeneratorContext:
         self.entered = True
         return self
 
-    def __exit__(
+    @wtt.spanned(
+        these=[
+            "self.queue._backend_name",
+            "self.queue._address",
+            "self.queue._name",
+            "self.queue._prefetch",
+            "self.queue.timeout",
+        ],
+        kind=wtt.SpanKind.CONSUMER,
+    )
+    def __exit__(  # TODO: better as an event?
         self,
         exc_type: Optional[Type[BaseException]],
         exc_val: Optional[BaseException],
@@ -357,6 +378,16 @@ class MessageGeneratorContext:
                 logging.debug("[MessageGeneratorContext.__exit__()] exited w/o error.")
             return True  # suppress any Exception
 
+    @wtt.spanned(  # TODO: better as an event?
+        these=[
+            "self.queue._backend_name",
+            "self.queue._address",
+            "self.queue._name",
+            "self.queue._prefetch",
+            "self.queue.timeout",
+        ],
+        kind=wtt.SpanKind.CONSUMER,
+    )
     def __iter__(self) -> "MessageGeneratorContext":
         """Return instance.
 
@@ -367,6 +398,16 @@ class MessageGeneratorContext:
             raise RuntimeError(self.RUNTIME_ERROR_CONTEXT_STRING)
         return self
 
+    @wtt.spanned(  # TODO: better as an event?
+        these=[
+            "self.queue._backend_name",
+            "self.queue._address",
+            "self.queue._name",
+            "self.queue._prefetch",
+            "self.queue.timeout",
+        ],
+        kind=wtt.SpanKind.CONSUMER,
+    )
     def __next__(self) -> Any:
         """Return next Message in queue."""
         logging.debug("[MessageGeneratorContext.__next__()] next iteration...")

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -121,7 +121,7 @@ class Queue:
         """
         # TODO - add carrier! what about adding a `msg.headers` attr?
         # msg = Message.serialize_data(data, headers=wtt.inject_links_carrier())
-        msg = Message.serialize_data(data)
+        msg = Message.serialize(data)
         self.raw_pub_queue.send_message(msg)
 
     @wtt.spanned(
@@ -246,7 +246,7 @@ class Queue:
         if not msg:
             raise Exception("No message available")
 
-        data = msg.deserialize_data()
+        data = msg.data()
         try:
             yield data
         except Exception:  # pylint:disable=broad-except
@@ -421,4 +421,4 @@ class MessageGeneratorContext:
                 "Yielded value is `None`. This should not have happened."
             )
 
-        return self.msg.deserialize_data()
+        return self.msg.data()

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -35,7 +35,7 @@ class Queue:
         except_errors: bool = True,
     ) -> None:
         self._backend = backend
-        self._backend_name = self._backend.__class__.__name__
+        self._backend_name = str(self._backend.__class__)
         self._address = address
         self._name = name if name else Queue.make_name()
         self._prefetch = prefetch

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -174,15 +174,6 @@ class Queue:
         else:
             raise RuntimeError(f"Unrecognized AckStatus value: {msg.ack_status}")
 
-    @wtt.spanned(
-        these=[
-            "self._backend_name",
-            "self._address",
-            "self._name",
-            "self._prefetch",
-            "self.timeout",
-        ]
-    )
     def recv(self) -> "MessageGeneratorContext":
         """Receive a stream of messages from the queue.
 

--- a/mqclient/requirements.txt
+++ b/mqclient/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/WIPACrepo/wipac-telemetry-prototype@v0.1.9#egg=wipac_telemetry
 mypy
 pytest
 pytest-asyncio

--- a/mqclient/testing/integrate_backend_interface.py
+++ b/mqclient/testing/integrate_backend_interface.py
@@ -16,7 +16,7 @@ from .utils import DATA_LIST, _log_recv, _log_send
 def _log_recv_message(recv_msg: Optional[Message]) -> None:
     recv_data = None
     if recv_msg:
-        recv_data = recv_msg.deserialize_data()
+        recv_data = recv_msg.data()
     _log_recv(f"{recv_msg} -> {recv_data}")
 
 
@@ -36,8 +36,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
-            pub.send_message(raw_data)
+            raw_payload = Message.serialize(msg)
+            pub.send_message(raw_payload)
             _log_send(msg)
 
         # receive
@@ -54,7 +54,7 @@ class PubSubBackendInterface:
                 break
 
             assert recv_msg
-            assert DATA_LIST[i] == recv_msg.deserialize_data()
+            assert DATA_LIST[i] == recv_msg.data()
 
             sub.ack_message(recv_msg)
 
@@ -68,8 +68,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
-            pub.send_message(raw_data)
+            raw_payload = Message.serialize(msg)
+            pub.send_message(raw_payload)
             _log_send(msg)
 
         # receive -- nack each message, once, and anticipate its redelivery
@@ -81,7 +81,7 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
+                redelivered_data = [m.data() for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
@@ -91,7 +91,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data() in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -122,15 +122,15 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
+                redelivered_data = [m.data() for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
             # send a message
             if data_to_send:
                 msg = data_to_send[0]
-                raw_data = Message.serialize_data(msg)
-                pub.send_message(raw_data)
+                raw_payload = Message.serialize(msg)
+                pub.send_message(raw_payload)
                 _log_send(msg)
                 data_to_send.remove(msg)
 
@@ -141,7 +141,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data() in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -162,8 +162,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
-            pub.send_message(raw_data)
+            raw_payload = Message.serialize(msg)
+            pub.send_message(raw_payload)
             _log_send(msg)
 
         # receive
@@ -172,7 +172,7 @@ class PubSubBackendInterface:
             logging.info(i)
             _log_recv_message(recv_msg)
             assert recv_msg
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data() in DATA_LIST
             last = i
             sub.ack_message(recv_msg)
 

--- a/mqclient/testing/integrate_backend_interface.py
+++ b/mqclient/testing/integrate_backend_interface.py
@@ -16,7 +16,7 @@ from .utils import DATA_LIST, _log_recv, _log_send
 def _log_recv_message(recv_msg: Optional[Message]) -> None:
     recv_data = None
     if recv_msg:
-        recv_data = recv_msg.data()
+        recv_data = recv_msg.deserialize_data()
     _log_recv(f"{recv_msg} -> {recv_data}")
 
 
@@ -36,8 +36,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_payload = Message.serialize(msg)
-            pub.send_message(raw_payload)
+            raw_data = Message.serialize_data(msg)
+            pub.send_message(raw_data)
             _log_send(msg)
 
         # receive
@@ -54,7 +54,7 @@ class PubSubBackendInterface:
                 break
 
             assert recv_msg
-            assert DATA_LIST[i] == recv_msg.data()
+            assert DATA_LIST[i] == recv_msg.deserialize_data()
 
             sub.ack_message(recv_msg)
 
@@ -68,8 +68,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_payload = Message.serialize(msg)
-            pub.send_message(raw_payload)
+            raw_data = Message.serialize_data(msg)
+            pub.send_message(raw_data)
             _log_send(msg)
 
         # receive -- nack each message, once, and anticipate its redelivery
@@ -81,7 +81,7 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.data() for m in redelivered_msgs]
+                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
@@ -91,7 +91,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.data() in DATA_LIST
+            assert recv_msg.deserialize_data() in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -122,15 +122,15 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.data() for m in redelivered_msgs]
+                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
             # send a message
             if data_to_send:
                 msg = data_to_send[0]
-                raw_payload = Message.serialize(msg)
-                pub.send_message(raw_payload)
+                raw_data = Message.serialize_data(msg)
+                pub.send_message(raw_data)
                 _log_send(msg)
                 data_to_send.remove(msg)
 
@@ -141,7 +141,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.data() in DATA_LIST
+            assert recv_msg.deserialize_data() in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -162,8 +162,8 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_payload = Message.serialize(msg)
-            pub.send_message(raw_payload)
+            raw_data = Message.serialize_data(msg)
+            pub.send_message(raw_data)
             _log_send(msg)
 
         # receive
@@ -172,7 +172,7 @@ class PubSubBackendInterface:
             logging.info(i)
             _log_recv_message(recv_msg)
             assert recv_msg
-            assert recv_msg.data() in DATA_LIST
+            assert recv_msg.deserialize_data() in DATA_LIST
             last = i
             sub.ack_message(recv_msg)
 

--- a/mqclient/testing/integrate_backend_interface.py
+++ b/mqclient/testing/integrate_backend_interface.py
@@ -16,7 +16,7 @@ from .utils import DATA_LIST, _log_recv, _log_send
 def _log_recv_message(recv_msg: Optional[Message]) -> None:
     recv_data = None
     if recv_msg:
-        recv_data = recv_msg.deserialize_data()
+        recv_data = recv_msg.data
     _log_recv(f"{recv_msg} -> {recv_data}")
 
 
@@ -36,7 +36,7 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
+            raw_data = Message.serialize(msg)
             pub.send_message(raw_data)
             _log_send(msg)
 
@@ -54,7 +54,7 @@ class PubSubBackendInterface:
                 break
 
             assert recv_msg
-            assert DATA_LIST[i] == recv_msg.deserialize_data()
+            assert DATA_LIST[i] == recv_msg.data
 
             sub.ack_message(recv_msg)
 
@@ -68,7 +68,7 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
+            raw_data = Message.serialize(msg)
             pub.send_message(raw_data)
             _log_send(msg)
 
@@ -81,7 +81,7 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
+                redelivered_data = [m.data for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
@@ -91,7 +91,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -122,14 +122,14 @@ class PubSubBackendInterface:
 
             # all messages have been acked and redelivered
             if len(redelivered_msgs) == len(DATA_LIST):
-                redelivered_data = [m.deserialize_data() for m in redelivered_msgs]
+                redelivered_data = [m.data for m in redelivered_msgs]
                 assert all((d in DATA_LIST) for d in redelivered_data)
                 break
 
             # send a message
             if data_to_send:
                 msg = data_to_send[0]
-                raw_data = Message.serialize_data(msg)
+                raw_data = Message.serialize(msg)
                 pub.send_message(raw_data)
                 _log_send(msg)
                 data_to_send.remove(msg)
@@ -141,7 +141,7 @@ class PubSubBackendInterface:
             if not recv_msg:
                 logging.info("waiting...")
                 continue
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data in DATA_LIST
 
             # message was redelivered, so ack it
             if recv_msg in nacked_msgs:
@@ -162,7 +162,7 @@ class PubSubBackendInterface:
 
         # send
         for msg in DATA_LIST:
-            raw_data = Message.serialize_data(msg)
+            raw_data = Message.serialize(msg)
             pub.send_message(raw_data)
             _log_send(msg)
 
@@ -172,7 +172,7 @@ class PubSubBackendInterface:
             logging.info(i)
             _log_recv_message(recv_msg)
             assert recv_msg
-            assert recv_msg.deserialize_data() in DATA_LIST
+            assert recv_msg.data in DATA_LIST
             last = i
             sub.ack_message(recv_msg)
 

--- a/mqclient/testing/integrate_queue.py
+++ b/mqclient/testing/integrate_queue.py
@@ -50,6 +50,8 @@ class PubSubQueue:
 
         assert all_were_received(all_recvd, [DATA_LIST[0]] + DATA_LIST)
 
+        assert 0  # TODO: remove
+
     def test_11(self, queue_name: str) -> None:
         """Test an individual pub and an individual sub."""
         all_recvd: List[Any] = []

--- a/mqclient/testing/unit_tests.py
+++ b/mqclient/testing/unit_tests.py
@@ -285,7 +285,7 @@ class BackendUnitTest:
         if is_instance_by_name(self.backend, "rabbitmq.Backend"):  # HACK - manually set attr
             mock_con.return_value.is_closed = False
 
-        fake_data = [Message.serialize_data('baz')]
+        fake_data = [Message.serialize('baz')]
         self._enqueue_mock_messages(mock_con, fake_data, [0])
 
         with q.recv() as gen:
@@ -309,7 +309,7 @@ class BackendUnitTest:
         if is_instance_by_name(self.backend, "rabbitmq.Backend"):  # HACK - manually set attr
             mock_con.return_value.is_closed = False
 
-        fake_data = [Message.serialize_data('baz-0'), Message.serialize_data('baz-1')]
+        fake_data = [Message.serialize('baz-0'), Message.serialize('baz-1')]
         fake_ids = [0, 1]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids, append_none=False)
 
@@ -337,7 +337,7 @@ class BackendUnitTest:
 
         num_msgs = 12
 
-        fake_data = [Message.serialize_data(f'baz-{i}') for i in range(num_msgs)]
+        fake_data = [Message.serialize(f'baz-{i}') for i in range(num_msgs)]
         fake_ids = [i * 10 for i in range(num_msgs)]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids)
 
@@ -380,7 +380,7 @@ class BackendUnitTest:
 
         num_msgs = 12
 
-        fake_data = [Message.serialize_data(f'baz-{i}') for i in range(num_msgs)]
+        fake_data = [Message.serialize(f'baz-{i}') for i in range(num_msgs)]
         fake_ids = [i * 10 for i in range(num_msgs)]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids)
 

--- a/mqclient/testing/unit_tests.py
+++ b/mqclient/testing/unit_tests.py
@@ -106,7 +106,7 @@ class BackendUnitTest:
                 self._get_mock_ack(mock_con).assert_not_called()  # would be called by Queue
             assert msg is not None
             assert msg.msg_id == fake_ids[i]
-            assert msg.data == fake_data[i]
+            assert msg.payload == fake_data[i]
 
         # last_id = (num_msgs - 1) * 10
         self._get_mock_ack(mock_con).assert_not_called()  # would be called by Queue
@@ -130,7 +130,7 @@ class BackendUnitTest:
 
         assert m is not None
         assert m.msg_id == 12
-        assert m.data == b'foo, bar'
+        assert m.payload == b'foo, bar'
         self._get_mock_ack(mock_con).assert_not_called()  # would be called by Queue
         self._get_mock_close(mock_con).assert_not_called()  # would be called by Queue
 
@@ -148,7 +148,7 @@ class BackendUnitTest:
             m = x
         assert m is not None
         assert m.msg_id == 12
-        assert m.data == b'foo, bar'
+        assert m.payload == b'foo, bar'
         self._get_mock_ack(mock_con).assert_not_called()  # would be called by Queue
         self._get_mock_close(mock_con).assert_not_called()  # would be called by Queue
 
@@ -182,7 +182,7 @@ class BackendUnitTest:
 
             assert msg is not None
             assert msg.msg_id == i
-            assert msg.data == fake_data[i]
+            assert msg.payload == fake_data[i]
 
             i += 1
 
@@ -210,7 +210,7 @@ class BackendUnitTest:
 
             assert msg is not None
             assert msg.msg_id == i
-            assert msg.data == fake_data[i]
+            assert msg.payload == fake_data[i]
 
             if i == 2:
                 with pytest.raises(Exception):
@@ -245,7 +245,7 @@ class BackendUnitTest:
 
             assert msg is not None
             assert msg.msg_id == i * 10
-            assert msg.data == fake_data[i]
+            assert msg.payload == fake_data[i]
 
             if i % 2 == 0:
                 gen.throw(Exception)

--- a/mqclient/testing/unit_tests.py
+++ b/mqclient/testing/unit_tests.py
@@ -285,7 +285,7 @@ class BackendUnitTest:
         if is_instance_by_name(self.backend, "rabbitmq.Backend"):  # HACK - manually set attr
             mock_con.return_value.is_closed = False
 
-        fake_data = [Message.serialize('baz')]
+        fake_data = [Message.serialize_data('baz')]
         self._enqueue_mock_messages(mock_con, fake_data, [0])
 
         with q.recv() as gen:
@@ -309,7 +309,7 @@ class BackendUnitTest:
         if is_instance_by_name(self.backend, "rabbitmq.Backend"):  # HACK - manually set attr
             mock_con.return_value.is_closed = False
 
-        fake_data = [Message.serialize('baz-0'), Message.serialize('baz-1')]
+        fake_data = [Message.serialize_data('baz-0'), Message.serialize_data('baz-1')]
         fake_ids = [0, 1]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids, append_none=False)
 
@@ -337,7 +337,7 @@ class BackendUnitTest:
 
         num_msgs = 12
 
-        fake_data = [Message.serialize(f'baz-{i}') for i in range(num_msgs)]
+        fake_data = [Message.serialize_data(f'baz-{i}') for i in range(num_msgs)]
         fake_ids = [i * 10 for i in range(num_msgs)]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids)
 
@@ -380,7 +380,7 @@ class BackendUnitTest:
 
         num_msgs = 12
 
-        fake_data = [Message.serialize(f'baz-{i}') for i in range(num_msgs)]
+        fake_data = [Message.serialize_data(f'baz-{i}') for i in range(num_msgs)]
         fake_ids = [i * 10 for i in range(num_msgs)]
         self._enqueue_mock_messages(mock_con, fake_data, fake_ids)
 

--- a/tests/test_backend_interface.py
+++ b/tests/test_backend_interface.py
@@ -15,4 +15,4 @@ def test_Message() -> None:
     """Test Message."""
     m = backend_interface.Message('foo', b'abc')
     assert m.msg_id == 'foo'
-    assert m.data == b'abc'
+    assert m.payload == b'abc'

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -40,7 +40,7 @@ def test_send() -> None:
     data = {'a': 1234}
     q.send(data)
 
-    q.raw_pub_queue.send_message.assert_called_with(Message.serialize(data))  # type: ignore
+    q.raw_pub_queue.send_message.assert_called_with(Message.serialize_data(data))  # type: ignore
 
 
 def test_recv() -> None:
@@ -48,7 +48,7 @@ def test_recv() -> None:
 
     def gen(data: List[Any], *args: Any, **kwargs: Any) -> Generator[Message, None, None]:
         for i, d in enumerate(data):
-            yield Message(i, Message.serialize(d))
+            yield Message(i, Message.serialize_data(d))
 
     backend = MagicMock()
 
@@ -70,7 +70,7 @@ def test_recv_one() -> None:
     q = Queue(backend)
 
     data = {"b": 100}
-    msg = Message(0, Message.serialize(data))
+    msg = Message(0, Message.serialize_data(data))
     backend.create_sub_queue.return_value.get_message.return_value = msg
 
     with q.recv_one() as d:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -5,7 +5,7 @@
 
 from functools import partial
 from typing import Any, Generator, List
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, sentinel
 
 # local imports
 from mqclient.backend_interface import Backend, Message
@@ -40,7 +40,9 @@ def test_send() -> None:
     data = {'a': 1234}
     q.send(data)
 
-    q.raw_pub_queue.send_message.assert_called_with(Message.serialize(data))  # type: ignore
+    # send() adds a unique header, so we need to look at only the data
+    msg = Message(id(sentinel.ID), q.raw_pub_queue.send_message.call_args.args[0])  # type: ignore[attr-defined]
+    assert msg.data == data
 
 
 def test_recv() -> None:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -40,7 +40,7 @@ def test_send() -> None:
     data = {'a': 1234}
     q.send(data)
 
-    q.raw_pub_queue.send_message.assert_called_with(Message.serialize_data(data))  # type: ignore
+    q.raw_pub_queue.send_message.assert_called_with(Message.serialize(data))  # type: ignore
 
 
 def test_recv() -> None:
@@ -48,7 +48,7 @@ def test_recv() -> None:
 
     def gen(data: List[Any], *args: Any, **kwargs: Any) -> Generator[Message, None, None]:
         for i, d in enumerate(data):
-            yield Message(i, Message.serialize_data(d))
+            yield Message(i, Message.serialize(d))
 
     backend = MagicMock()
 
@@ -70,7 +70,7 @@ def test_recv_one() -> None:
     q = Queue(backend)
 
     data = {"b": 100}
-    msg = Message(0, Message.serialize_data(data))
+    msg = Message(0, Message.serialize(data))
     backend.create_sub_queue.return_value.get_message.return_value = msg
 
     with q.recv_one() as d:


### PR DESCRIPTION
Adds producer-consumer tracing for the `Queue` and `MessageGeneratorContext` classes.

Adds a `"headers"` field to each `Message` instance. Previous data is now in the `"data"` field.

closes https://github.com/WIPACrepo/MQClient/issues/12