### PR TITLE
Add Auth Token Support

### DIFF
--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -156,11 +156,13 @@ class Backend:
     """Backend Pub-Sub Factory."""
 
     @staticmethod
-    def create_pub_queue(address: str, name: str) -> Pub:
+    def create_pub_queue(address: str, name: str, auth_token: str = "") -> Pub:
         """Create a publishing queue."""
         raise NotImplementedError()
 
     @staticmethod
-    def create_sub_queue(address: str, name: str, prefetch: int = 1) -> Sub:
+    def create_sub_queue(
+        address: str, name: str, prefetch: int = 1, auth_token: str = ""
+    ) -> Sub:
         """Create a subscription queue."""
         raise NotImplementedError()


### PR DESCRIPTION
Adds an optional parameter to `Queue`, `auth_token`, to handle auth things. Specific transformations are left to the respective backend MQ implementation.

This needs to be pushed through before testing.

closes https://github.com/WIPACrepo/MQClient/issues/20