### PR TITLE
Improve Queue Cleanup

### DIFF
--- a/mqclient/abstract_backend_tests/integrate_backend_interface.py
+++ b/mqclient/abstract_backend_tests/integrate_backend_interface.py
@@ -62,6 +62,9 @@ class PubSubBackendInterface:
 
             await sub.ack_message(recv_msg)
 
+        pub.close()
+        sub.close()
+
     @pytest.mark.asyncio
     async def test_10(self, queue_name: str) -> None:
         """Test nacking, front-loaded sending.
@@ -109,6 +112,9 @@ class PubSubBackendInterface:
                 nacked_msgs.append(recv_msg)
                 await sub.reject_message(recv_msg)
                 logging.info("NACK!")
+
+        pub.close()
+        sub.close()
 
     @pytest.mark.asyncio
     async def test_11(self, queue_name: str) -> None:
@@ -161,6 +167,9 @@ class PubSubBackendInterface:
                 await sub.reject_message(recv_msg)
                 logging.info("NACK!")
 
+        pub.close()
+        sub.close()
+
     @pytest.mark.asyncio
     async def test_20(self, queue_name: str) -> None:
         """Sanity test message generator."""
@@ -187,3 +196,6 @@ class PubSubBackendInterface:
             await sub.ack_message(recv_msg)
 
         assert last == len(DATA_LIST) - 1
+
+        pub.close()
+        sub.close()

--- a/mqclient/abstract_backend_tests/integrate_backend_interface.py
+++ b/mqclient/abstract_backend_tests/integrate_backend_interface.py
@@ -62,8 +62,8 @@ class PubSubBackendInterface:
 
             await sub.ack_message(recv_msg)
 
-        pub.close()
-        sub.close()
+        await pub.close()
+        await sub.close()
 
     @pytest.mark.asyncio
     async def test_10(self, queue_name: str) -> None:
@@ -113,8 +113,8 @@ class PubSubBackendInterface:
                 await sub.reject_message(recv_msg)
                 logging.info("NACK!")
 
-        pub.close()
-        sub.close()
+        await pub.close()
+        await sub.close()
 
     @pytest.mark.asyncio
     async def test_11(self, queue_name: str) -> None:
@@ -167,8 +167,8 @@ class PubSubBackendInterface:
                 await sub.reject_message(recv_msg)
                 logging.info("NACK!")
 
-        pub.close()
-        sub.close()
+        await pub.close()
+        await sub.close()
 
     @pytest.mark.asyncio
     async def test_20(self, queue_name: str) -> None:
@@ -197,5 +197,5 @@ class PubSubBackendInterface:
 
         assert last == len(DATA_LIST) - 1
 
-        pub.close()
-        sub.close()
+        await pub.close()
+        await sub.close()

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -33,17 +33,17 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub_sub = Queue(self.backend, name=queue_name)
-        async with pub_sub.sender() as send:
-            await send(DATA_LIST[0])
+        async with pub_sub.sender() as s:
+            await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         async with pub_sub.recv_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub_sub.sender() as send:
+        async with pub_sub.sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         pub_sub.timeout = 1
@@ -61,8 +61,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
-            await send(DATA_LIST[0])
+        async with pub.sender() as s:
+            await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         sub = Queue(self.backend, name=queue_name)
@@ -70,9 +70,9 @@ class PubSubQueue:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub.sender() as send:
+        async with pub.sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         sub.timeout = 1
@@ -89,8 +89,8 @@ class PubSubQueue:
         """Failure-test one pub, two subs (one subscribed to wrong queue)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
-            await send(DATA_LIST[0])
+        async with Queue(self.backend, name=queue_name).sender() as s:
+            await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         with pytest.raises(Exception) as excinfo:
@@ -110,9 +110,9 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         # for each send, create and receive message via a new sub
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for data in DATA_LIST:
-                await send(data)
+                await s.send(data)
                 _log_send(data)
 
                 async with Queue(self.backend, name=queue_name).recv_one() as d:
@@ -125,9 +125,9 @@ class PubSubQueue:
         """Test one pub, multiple subs, unordered (front-loaded sending)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for data in DATA_LIST:
-                await send(data)
+                await s.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> List[Any]:
@@ -178,9 +178,9 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for data in DATA_LIST:
-                await send(data)
+                await s.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
@@ -205,9 +205,9 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for data in DATA_LIST:
-                await send(data)
+                await s.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
@@ -236,8 +236,8 @@ class PubSubQueue:
         sub = Queue(self.backend, name=queue_name)
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
             sub.timeout = 1
@@ -257,8 +257,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
         sub = Queue(self.backend, name=queue_name)
@@ -278,8 +278,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
             sub = Queue(self.backend, name=queue_name)
@@ -302,8 +302,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
         for _ in range(len(DATA_LIST)):
@@ -321,8 +321,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
         for i in range(len(DATA_LIST)):
@@ -343,8 +343,8 @@ class PubSubQueue:
 
         for data_pairs in [DATA_LIST[i : i + 2] for i in range(0, len(DATA_LIST), 2)]:
             for data in data_pairs:
-                async with Queue(self.backend, name=queue_name).sender() as send:
-                    await send(data)
+                async with Queue(self.backend, name=queue_name).sender() as s:
+                    await s.send(data)
                     _log_send(data)
 
         for _ in range(len(DATA_LIST)):
@@ -361,11 +361,11 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for i in range(1, len(DATA_LIST) * 2):
                 # for each send, create and receive message via a new sub
                 for data in DATA_LIST:
-                    await send(data)
+                    await s.send(data)
                     _log_send(data)
 
                     sub = Queue(self.backend, name=queue_name, prefetch=i)
@@ -384,8 +384,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as send:
-                await send(data)
+            async with Queue(self.backend, name=queue_name).sender() as s:
+                await s.send(data)
                 _log_send(data)
 
         # this should not eat up the whole queue
@@ -408,9 +408,9 @@ class PubSubQueue:
         """Test recv() fail and recovery, with multiple recv() calls."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         class TestException(Exception):  # pylint: disable=C0115
@@ -446,9 +446,9 @@ class PubSubQueue:
         """Test recv() fail and recovery, with error propagation."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         class TestException(Exception):  # pylint: disable=C0115
@@ -487,9 +487,9 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_70_fail(self, queue_name: str) -> None:
         """Failure-test recv() with reusing a 'MessageAsyncGeneratorContext' instance."""
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         sub = Queue(self.backend, name=queue_name)
@@ -510,9 +510,9 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_80_break(self, queue_name: str) -> None:
         """Test recv() with a `break` statement."""
-        async with Queue(self.backend, name=queue_name).sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as s:
             for d in DATA_LIST:
-                await send(d)
+                await s.send(d)
                 _log_send(d)
 
         sub = Queue(self.backend, name=queue_name)

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -43,7 +43,7 @@ class PubSubQueue:
 
         async with pub_sub.sender() as s:
             for d in DATA_LIST:
-                await s.send(d)
+                await s.send(d, d, d)
                 _log_send(d)
 
         pub_sub.timeout = 1

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -43,7 +43,7 @@ class PubSubQueue:
 
         async with pub_sub.sender() as s:
             for d in DATA_LIST:
-                await s.send(d, d, d)
+                await s.send(d)
                 _log_send(d)
 
         pub_sub.timeout = 1

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -363,11 +363,12 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        for i, data in enumerate(DATA_LIST):
-            if i % 2 == 0:  # each pub sends 2 messages back-to-back
+        for data_pairs in [DATA_LIST[i : i + 2] for i in range(0, len(DATA_LIST), 2)]:
+            for data in data_pairs:
                 pub = Queue(self.backend, name=queue_name)
-            await pub.send(data)
-            _log_send(data)
+                async with pub.sender() as send:
+                    await send(data)
+                    _log_send(data)
 
         for _ in range(len(DATA_LIST)):
             sub = Queue(self.backend, name=queue_name)

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -33,16 +33,18 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub_sub = Queue(self.backend, name=queue_name)
-        await pub_sub.send(DATA_LIST[0])
+        async with pub_sub.sender() as send:
+            await send(DATA_LIST[0])
         _log_send(DATA_LIST[0])
 
         async with pub_sub.recv_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        for d in DATA_LIST:
-            await pub_sub.send(d)
-            _log_send(d)
+        async with pub_sub.sender() as send:
+            for d in DATA_LIST:
+                await send(d)
+                _log_send(d)
 
         pub_sub.timeout = 1
         async with pub_sub.recv() as gen:

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -89,19 +89,16 @@ class PubSubQueue:
         """Failure-test one pub, two subs (one subscribed to wrong queue)."""
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             await send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
-        sub_fail = Queue(self.backend, name=f"{queue_name}-fail")
         with pytest.raises(Exception) as excinfo:
-            async with sub_fail.recv_one() as d:
+            async with Queue(self.backend, name=f"{queue_name}-fail").recv_one() as d:
                 all_recvd.append(_log_recv(d))
             assert "No message available" in str(excinfo.value)
 
-        sub = Queue(self.backend, name=queue_name)
-        async with sub.recv_one() as d:
+        async with Queue(self.backend, name=queue_name).recv_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
@@ -112,19 +109,15 @@ class PubSubQueue:
         """Test one pub, multiple subs, ordered/alternatingly."""
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-
         # for each send, create and receive message via a new sub
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for data in DATA_LIST:
                 await send(data)
                 _log_send(data)
 
-                sub = Queue(self.backend, name=queue_name)
-                async with sub.recv_one() as d:
+                async with Queue(self.backend, name=queue_name).recv_one() as d:
                     all_recvd.append(_log_recv(d))
                     assert d == data
-                # sub.close() -- no longer needed
 
         assert all_were_received(all_recvd)
 
@@ -132,8 +125,7 @@ class PubSubQueue:
         """Test one pub, multiple subs, unordered (front-loaded sending)."""
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for data in DATA_LIST:
                 await send(data)
                 _log_send(data)
@@ -186,17 +178,14 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for data in DATA_LIST:
                 await send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
-            sub = Queue(self.backend, name=queue_name)
-            async with sub.recv_one() as d:
+            async with Queue(self.backend, name=queue_name).recv_one() as d:
                 recv_data = d
-            # sub.close() -- no longer needed
             return _log_recv(recv_data)
 
         def start_recv_thread(num_id: int) -> Any:
@@ -216,17 +205,14 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for data in DATA_LIST:
                 await send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
-            sub = Queue(self.backend, name=queue_name)
-            async with sub.recv_one() as d:
+            async with Queue(self.backend, name=queue_name).recv_one() as d:
                 recv_data = d
-            # sub.close() -- no longer needed
             return _log_recv(recv_data)
 
         def start_recv_thread(num_id: int) -> Any:
@@ -250,8 +236,7 @@ class PubSubQueue:
         sub = Queue(self.backend, name=queue_name)
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
@@ -272,8 +257,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
@@ -294,8 +278,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
@@ -319,16 +302,13 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
         for _ in range(len(DATA_LIST)):
-            sub = Queue(self.backend, name=queue_name)
-            async with sub.recv_one() as d:
+            async with Queue(self.backend, name=queue_name).recv_one() as d:
                 all_recvd.append(_log_recv(d))
-            # sub.close() -- no longer needed
 
         assert all_were_received(all_recvd)
 
@@ -341,8 +321,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
@@ -351,7 +330,6 @@ class PubSubQueue:
                 sub = Queue(self.backend, name=queue_name)
             async with sub.recv_one() as d:
                 all_recvd.append(_log_recv(d))
-            # sub.close() -- no longer needed
 
         assert all_were_received(all_recvd)
 
@@ -365,16 +343,13 @@ class PubSubQueue:
 
         for data_pairs in [DATA_LIST[i : i + 2] for i in range(0, len(DATA_LIST), 2)]:
             for data in data_pairs:
-                pub = Queue(self.backend, name=queue_name)
-                async with pub.sender() as send:
+                async with Queue(self.backend, name=queue_name).sender() as send:
                     await send(data)
                     _log_send(data)
 
         for _ in range(len(DATA_LIST)):
-            sub = Queue(self.backend, name=queue_name)
-            async with sub.recv_one() as d:
+            async with Queue(self.backend, name=queue_name).recv_one() as d:
                 all_recvd.append(_log_recv(d))
-            # sub.close() -- no longer needed
 
         assert all_were_received(all_recvd)
 
@@ -386,9 +361,7 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for i in range(1, len(DATA_LIST) * 2):
                 # for each send, create and receive message via a new sub
                 for data in DATA_LIST:
@@ -399,7 +372,6 @@ class PubSubQueue:
                     async with sub.recv_one() as d:
                         all_recvd.append(_log_recv(d))
                         assert d == data
-                    # sub.close() -- no longer needed
 
         assert all_were_received(all_recvd, DATA_LIST * ((len(DATA_LIST) * 2) - 1))
 
@@ -412,8 +384,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            pub = Queue(self.backend, name=queue_name)
-            async with pub.sender() as send:
+            async with Queue(self.backend, name=queue_name).sender() as send:
                 await send(data)
                 _log_send(data)
 
@@ -423,7 +394,6 @@ class PubSubQueue:
             all_recvd.append(_log_recv(d))
         async with sub.recv_one() as d:
             all_recvd.append(_log_recv(d))
-        # sub.close() -- no longer needed
 
         sub2 = Queue(self.backend, name=queue_name, prefetch=2)
         sub2.timeout = 1
@@ -438,8 +408,7 @@ class PubSubQueue:
         """Test recv() fail and recovery, with multiple recv() calls."""
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for d in DATA_LIST:
                 await send(d)
                 _log_send(d)
@@ -477,8 +446,7 @@ class PubSubQueue:
         """Test recv() fail and recovery, with error propagation."""
         all_recvd: List[Any] = []
 
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for d in DATA_LIST:
                 await send(d)
                 _log_send(d)
@@ -519,8 +487,7 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_70_fail(self, queue_name: str) -> None:
         """Failure-test recv() with reusing a 'MessageAsyncGeneratorContext' instance."""
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for d in DATA_LIST:
                 await send(d)
                 _log_send(d)
@@ -543,8 +510,7 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_80_break(self, queue_name: str) -> None:
         """Test recv() with a `break` statement."""
-        pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as send:
+        async with Queue(self.backend, name=queue_name).sender() as send:
             for d in DATA_LIST:
                 await send(d)
                 _log_send(d)

--- a/mqclient/backend_interface.py
+++ b/mqclient/backend_interface.py
@@ -12,6 +12,10 @@ RETRY_DELAY = 1  # seconds
 TRY_ATTEMPTS = 3  # ex: 3 means 1 initial try and 2 retries
 
 
+class ConnectingFailedExcpetion(Exception):
+    """Raised when a `connect()` invocation fails."""
+
+
 class ClosingFailedExcpetion(Exception):
     """Raised when a `close()` invocation fails."""
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -319,7 +319,7 @@ class MessageAsyncGeneratorContext:
         self.gen = self.sub.message_generator(
             timeout=self.queue.timeout,
             propagate_error=(not self.queue.except_errors),
-        )  # type: ignore[assignment] # python does magic to make coroutine into an async generator
+        )
 
         self._span = wtt.get_current_span()
         self._span_carrier = wtt.inject_span_carrier()

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -430,10 +430,12 @@ class MessageAsyncGeneratorContext:
         try:
             self.msg = get_message_callback(await self.gen.__anext__())
         except StopAsyncIteration:
+            self.msg = None  # signal there is no message to ack/nack in `__aexit__()`
             logging.debug(
                 "[MessageAsyncGeneratorContext.__anext__()] end of loop (StopAsyncIteration)"
             )
             raise
+
         if not self.msg:
             raise RuntimeError(
                 "Yielded value is `None`. This should not have happened."

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -248,8 +248,7 @@ class Queue:
             f"address={self._address}, "
             f"name={self._name}, "
             f"prefetch={self._prefetch}, "
-            f"timeout={self.timeout}, "
-            f"pub={bool(self._pub_queue)}"
+            f"timeout={self.timeout}"
             f")"
         )
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -32,8 +32,8 @@ async def test_send() -> None:
     q = Queue(mock_backend)
 
     data = {"a": 1234}
-    async with q.sender() as send:
-        await send(data)
+    async with q.sender() as s:
+        await s.send(data)
     mock_backend.create_pub_queue.return_value.send_message.assert_awaited()
 
     # send() adds a unique header, so we need to look at only the data

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -24,15 +24,7 @@ def test_init() -> None:
     assert q._prefetch == 999
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
-async def test_pub() -> None:
-    """Test pub."""
-    mock_backend = AsyncMock()
-    q = Queue(mock_backend)
-    assert (await q.raw_pub_queue) == mock_backend.create_pub_queue.return_value
-
-
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_send() -> None:
     """Test send."""
     mock_backend = AsyncMock()
@@ -40,7 +32,8 @@ async def test_send() -> None:
     q = Queue(mock_backend)
 
     data = {"a": 1234}
-    await q.send(data)
+    async with q.sender() as send:
+        await send(data)
     mock_backend.create_pub_queue.return_value.send_message.assert_awaited()
 
     # send() adds a unique header, so we need to look at only the data
@@ -51,7 +44,7 @@ async def test_send() -> None:
     assert msg.data == data
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_recv() -> None:
     """Test recv."""
 
@@ -73,7 +66,7 @@ async def test_recv() -> None:
         assert data == recv_data
 
 
-@pytest.mark.asyncio  # type: ignore[misc]
+@pytest.mark.asyncio
 async def test_recv_one() -> None:
     """Test recv_one."""
     mock_backend = AsyncMock()


### PR DESCRIPTION
- Changes `Queue.send()` to an async context manager, `Queue.sender()` which yields an instance with a `send()` method that can be called multiple times.
- Fixes a possible double-ack when the message loop (`MessageAsyncGeneratorContext`) exits