### PR TITLE
Rename Public-Facing API Methods [minor]

### DIFF
--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -37,7 +37,7 @@ class PubSubQueue:
             await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
-        async with pub_sub.recv_one() as d:
+        async with pub_sub.open_sub_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
@@ -66,7 +66,7 @@ class PubSubQueue:
             _log_send(DATA_LIST[0])
 
         sub = Queue(self.backend, name=queue_name)
-        async with sub.recv_one() as d:
+        async with sub.open_sub_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
@@ -94,11 +94,13 @@ class PubSubQueue:
             _log_send(DATA_LIST[0])
 
         with pytest.raises(Exception) as excinfo:
-            async with Queue(self.backend, name=f"{queue_name}-fail").recv_one() as d:
+            async with Queue(
+                self.backend, name=f"{queue_name}-fail"
+            ).open_sub_one() as d:
                 all_recvd.append(_log_recv(d))
             assert "No message available" in str(excinfo.value)
 
-        async with Queue(self.backend, name=queue_name).recv_one() as d:
+        async with Queue(self.backend, name=queue_name).open_sub_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
@@ -115,7 +117,7 @@ class PubSubQueue:
                 await s.send(data)
                 _log_send(data)
 
-                async with Queue(self.backend, name=queue_name).recv_one() as d:
+                async with Queue(self.backend, name=queue_name).open_sub_one() as d:
                     all_recvd.append(_log_recv(d))
                     assert d == data
 
@@ -184,7 +186,7 @@ class PubSubQueue:
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
-            async with Queue(self.backend, name=queue_name).recv_one() as d:
+            async with Queue(self.backend, name=queue_name).open_sub_one() as d:
                 recv_data = d
             return _log_recv(recv_data)
 
@@ -200,7 +202,7 @@ class PubSubQueue:
     async def test_23(self, queue_name: str) -> None:
         """Failure-test one pub, and too many subs.
 
-        More subs than messages with `recv_one()` will raise an
+        More subs than messages with `open_sub_one()` will raise an
         exception.
         """
         all_recvd: List[Any] = []
@@ -211,7 +213,7 @@ class PubSubQueue:
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
-            async with Queue(self.backend, name=queue_name).recv_one() as d:
+            async with Queue(self.backend, name=queue_name).open_sub_one() as d:
                 recv_data = d
             return _log_recv(recv_data)
 
@@ -307,7 +309,7 @@ class PubSubQueue:
                 _log_send(data)
 
         for _ in range(len(DATA_LIST)):
-            async with Queue(self.backend, name=queue_name).recv_one() as d:
+            async with Queue(self.backend, name=queue_name).open_sub_one() as d:
                 all_recvd.append(_log_recv(d))
 
         assert all_were_received(all_recvd)
@@ -328,7 +330,7 @@ class PubSubQueue:
         for i in range(len(DATA_LIST)):
             if i % 2 == 0:  # each sub receives 2 messages back-to-back
                 sub = Queue(self.backend, name=queue_name)
-            async with sub.recv_one() as d:
+            async with sub.open_sub_one() as d:
                 all_recvd.append(_log_recv(d))
 
         assert all_were_received(all_recvd)
@@ -348,7 +350,7 @@ class PubSubQueue:
                     _log_send(data)
 
         for _ in range(len(DATA_LIST)):
-            async with Queue(self.backend, name=queue_name).recv_one() as d:
+            async with Queue(self.backend, name=queue_name).open_sub_one() as d:
                 all_recvd.append(_log_recv(d))
 
         assert all_were_received(all_recvd)
@@ -369,7 +371,7 @@ class PubSubQueue:
                     _log_send(data)
 
                     sub = Queue(self.backend, name=queue_name, prefetch=i)
-                    async with sub.recv_one() as d:
+                    async with sub.open_sub_one() as d:
                         all_recvd.append(_log_recv(d))
                         assert d == data
 
@@ -390,9 +392,9 @@ class PubSubQueue:
 
         # this should not eat up the whole queue
         sub = Queue(self.backend, name=queue_name, prefetch=20)
-        async with sub.recv_one() as d:
+        async with sub.open_sub_one() as d:
             all_recvd.append(_log_recv(d))
-        async with sub.recv_one() as d:
+        async with sub.open_sub_one() as d:
             all_recvd.append(_log_recv(d))
 
         sub2 = Queue(self.backend, name=queue_name, prefetch=2)

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -33,7 +33,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub_sub = Queue(self.backend, name=queue_name)
-        async with pub_sub.sender() as s:
+        async with pub_sub.open_pub() as s:
             await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
@@ -41,7 +41,7 @@ class PubSubQueue:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub_sub.sender() as s:
+        async with pub_sub.open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)
@@ -61,7 +61,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub = Queue(self.backend, name=queue_name)
-        async with pub.sender() as s:
+        async with pub.open_pub() as s:
             await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
@@ -70,7 +70,7 @@ class PubSubQueue:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub.sender() as s:
+        async with pub.open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)
@@ -89,7 +89,7 @@ class PubSubQueue:
         """Failure-test one pub, two subs (one subscribed to wrong queue)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             await s.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
@@ -110,7 +110,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         # for each send, create and receive message via a new sub
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for data in DATA_LIST:
                 await s.send(data)
                 _log_send(data)
@@ -125,7 +125,7 @@ class PubSubQueue:
         """Test one pub, multiple subs, unordered (front-loaded sending)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for data in DATA_LIST:
                 await s.send(data)
                 _log_send(data)
@@ -178,7 +178,7 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for data in DATA_LIST:
                 await s.send(data)
                 _log_send(data)
@@ -205,7 +205,7 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for data in DATA_LIST:
                 await s.send(data)
                 _log_send(data)
@@ -236,7 +236,7 @@ class PubSubQueue:
         sub = Queue(self.backend, name=queue_name)
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -257,7 +257,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -278,7 +278,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -302,7 +302,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -321,7 +321,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -343,7 +343,7 @@ class PubSubQueue:
 
         for data_pairs in [DATA_LIST[i : i + 2] for i in range(0, len(DATA_LIST), 2)]:
             for data in data_pairs:
-                async with Queue(self.backend, name=queue_name).sender() as s:
+                async with Queue(self.backend, name=queue_name).open_pub() as s:
                     await s.send(data)
                     _log_send(data)
 
@@ -361,7 +361,7 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for i in range(1, len(DATA_LIST) * 2):
                 # for each send, create and receive message via a new sub
                 for data in DATA_LIST:
@@ -384,7 +384,7 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).sender() as s:
+            async with Queue(self.backend, name=queue_name).open_pub() as s:
                 await s.send(data)
                 _log_send(data)
 
@@ -408,7 +408,7 @@ class PubSubQueue:
         """Test recv() fail and recovery, with multiple recv() calls."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)
@@ -446,7 +446,7 @@ class PubSubQueue:
         """Test recv() fail and recovery, with error propagation."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)
@@ -487,7 +487,7 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_70_fail(self, queue_name: str) -> None:
         """Failure-test recv() with reusing a 'MessageAsyncGeneratorContext' instance."""
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)
@@ -510,7 +510,7 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_80_break(self, queue_name: str) -> None:
         """Test recv() with a `break` statement."""
-        async with Queue(self.backend, name=queue_name).sender() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)
                 _log_send(d)

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -33,17 +33,17 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub_sub = Queue(self.backend, name=queue_name)
-        async with pub_sub.open_pub() as s:
-            await s.send(DATA_LIST[0])
+        async with pub_sub.open_pub() as p:
+            await p.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         async with pub_sub.open_sub_one() as d:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub_sub.open_pub() as s:
+        async with pub_sub.open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         pub_sub.timeout = 1
@@ -61,8 +61,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         pub = Queue(self.backend, name=queue_name)
-        async with pub.open_pub() as s:
-            await s.send(DATA_LIST[0])
+        async with pub.open_pub() as p:
+            await p.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         sub = Queue(self.backend, name=queue_name)
@@ -70,9 +70,9 @@ class PubSubQueue:
             all_recvd.append(_log_recv(d))
             assert d == DATA_LIST[0]
 
-        async with pub.open_pub() as s:
+        async with pub.open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         sub.timeout = 1
@@ -89,8 +89,8 @@ class PubSubQueue:
         """Failure-test one pub, two subs (one subscribed to wrong queue)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
-            await s.send(DATA_LIST[0])
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
+            await p.send(DATA_LIST[0])
             _log_send(DATA_LIST[0])
 
         with pytest.raises(Exception) as excinfo:
@@ -112,9 +112,9 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         # for each send, create and receive message via a new sub
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for data in DATA_LIST:
-                await s.send(data)
+                await p.send(data)
                 _log_send(data)
 
                 async with Queue(self.backend, name=queue_name).open_sub_one() as d:
@@ -127,9 +127,9 @@ class PubSubQueue:
         """Test one pub, multiple subs, unordered (front-loaded sending)."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for data in DATA_LIST:
-                await s.send(data)
+                await p.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> List[Any]:
@@ -180,9 +180,9 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for data in DATA_LIST:
-                await s.send(data)
+                await p.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
@@ -207,9 +207,9 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for data in DATA_LIST:
-                await s.send(data)
+                await p.send(data)
                 _log_send(data)
 
         async def recv_thread(_: int) -> Any:
@@ -238,8 +238,8 @@ class PubSubQueue:
         sub = Queue(self.backend, name=queue_name)
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
             sub.timeout = 1
@@ -259,8 +259,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
         sub = Queue(self.backend, name=queue_name)
@@ -280,8 +280,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
             sub = Queue(self.backend, name=queue_name)
@@ -304,8 +304,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
         for _ in range(len(DATA_LIST)):
@@ -323,8 +323,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
         for i in range(len(DATA_LIST)):
@@ -345,8 +345,8 @@ class PubSubQueue:
 
         for data_pairs in [DATA_LIST[i : i + 2] for i in range(0, len(DATA_LIST), 2)]:
             for data in data_pairs:
-                async with Queue(self.backend, name=queue_name).open_pub() as s:
-                    await s.send(data)
+                async with Queue(self.backend, name=queue_name).open_pub() as p:
+                    await p.send(data)
                     _log_send(data)
 
         for _ in range(len(DATA_LIST)):
@@ -363,11 +363,11 @@ class PubSubQueue:
         """
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for i in range(1, len(DATA_LIST) * 2):
                 # for each send, create and receive message via a new sub
                 for data in DATA_LIST:
-                    await s.send(data)
+                    await p.send(data)
                     _log_send(data)
 
                     sub = Queue(self.backend, name=queue_name, prefetch=i)
@@ -386,8 +386,8 @@ class PubSubQueue:
         all_recvd: List[Any] = []
 
         for data in DATA_LIST:
-            async with Queue(self.backend, name=queue_name).open_pub() as s:
-                await s.send(data)
+            async with Queue(self.backend, name=queue_name).open_pub() as p:
+                await p.send(data)
                 _log_send(data)
 
         # this should not eat up the whole queue
@@ -410,9 +410,9 @@ class PubSubQueue:
         """Test open_sub() fail and recovery, with multiple open_sub() calls."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         class TestException(Exception):  # pylint: disable=C0115
@@ -448,9 +448,9 @@ class PubSubQueue:
         """Test open_sub() fail and recovery, with error propagation."""
         all_recvd: List[Any] = []
 
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         class TestException(Exception):  # pylint: disable=C0115
@@ -489,9 +489,9 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_70_fail(self, queue_name: str) -> None:
         """Failure-test open_sub() with reusing a 'QueueSubResource' instance."""
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         sub = Queue(self.backend, name=queue_name)
@@ -512,9 +512,9 @@ class PubSubQueue:
     @pytest.mark.asyncio
     async def test_80_break(self, queue_name: str) -> None:
         """Test open_sub() with a `break` statement."""
-        async with Queue(self.backend, name=queue_name).open_pub() as s:
+        async with Queue(self.backend, name=queue_name).open_pub() as p:
             for d in DATA_LIST:
-                await s.send(d)
+                await p.send(d)
                 _log_send(d)
 
         sub = Queue(self.backend, name=queue_name)

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -94,9 +94,8 @@ class PubSubQueue:
             _log_send(DATA_LIST[0])
 
         with pytest.raises(Exception) as excinfo:
-            async with Queue(
-                self.backend, name=f"{queue_name}-fail"
-            ).open_sub_one() as d:
+            name = f"{queue_name}-fail"
+            async with Queue(self.backend, name=name).open_sub_one() as d:
                 all_recvd.append(_log_recv(d))
             assert "No message available" in str(excinfo.value)
 

--- a/mqclient/abstract_backend_tests/integrate_queue.py
+++ b/mqclient/abstract_backend_tests/integrate_queue.py
@@ -486,7 +486,7 @@ class PubSubQueue:
 
     @pytest.mark.asyncio
     async def test_70_fail(self, queue_name: str) -> None:
-        """Failure-test open_sub() with reusing a 'MessageAsyncGeneratorContext' instance."""
+        """Failure-test open_sub() with reusing a 'QueueSubResource' instance."""
         async with Queue(self.backend, name=queue_name).open_pub() as s:
             for d in DATA_LIST:
                 await s.send(d)

--- a/mqclient/abstract_backend_tests/unit_tests.py
+++ b/mqclient/abstract_backend_tests/unit_tests.py
@@ -300,7 +300,7 @@ class BackendUnitTest:
     ) -> None:
         """Failure-test message generator.
 
-        Not so much a test, as an example of why MessageAsyncGeneratorContext
+        Not so much a test, as an example of why QueueSubResource
         is needed.
         """
         sub = await self.backend.create_sub_queue("localhost", queue_name)
@@ -315,9 +315,7 @@ class BackendUnitTest:
                 logging.debug(msg)
                 raise Exception
         except Exception:
-            excepted = (
-                True  # MessageAsyncGeneratorContext would've suppressed the Exception
-            )
+            excepted = True  # QueueSubResource would've suppressed the Exception
         assert excepted
 
         # would be called by Queue

--- a/mqclient/abstract_backend_tests/unit_tests.py
+++ b/mqclient/abstract_backend_tests/unit_tests.py
@@ -328,7 +328,7 @@ class BackendUnitTest:
 
     @pytest.mark.asyncio
     async def test_queue_recv_00_consumer(self, mock_con: Any, queue_name: str) -> None:
-        """Test Queue.recv()."""
+        """Test Queue.open_sub()."""
         q = Queue(self.backend, address="localhost", name=queue_name)
         if is_inst_name(self.backend, "rabbitmq.Backend"):  # HACK: manually set attr
             mock_con.return_value.is_closed = False
@@ -336,7 +336,7 @@ class BackendUnitTest:
         fake_data = [Message.serialize("baz")]
         await self._enqueue_mock_messages(mock_con, fake_data, [0])
 
-        async with q.recv() as gen:
+        async with q.open_sub() as gen:
             async for msg in gen:
                 logging.debug(msg)
                 assert msg
@@ -349,7 +349,7 @@ class BackendUnitTest:
     async def test_queue_recv_10_comsumer_exception(
         self, mock_con: Any, queue_name: str
     ) -> None:
-        """Failure-test Queue.recv().
+        """Failure-test Queue.open_sub().
 
         When an Exception is raised in `with` block, the Queue should:
         - close (sub) on exit
@@ -369,7 +369,7 @@ class BackendUnitTest:
         class TestException(Exception):  # pylint: disable=C0115
             pass
 
-        async with q.recv() as gen:  # suppress_errors=True
+        async with q.open_sub() as gen:  # suppress_errors=True
             async for i, msg in asl.enumerate(gen):
                 assert i == 0
                 logging.debug(msg)
@@ -382,10 +382,10 @@ class BackendUnitTest:
     async def test_queue_recv_11_comsumer_exception(
         self, mock_con: Any, queue_name: str
     ) -> None:
-        """Failure-test Queue.recv().
+        """Failure-test Queue.open_sub().
 
         Same as test_queue_recv_10_comsumer_exception() but with multiple
-        recv() calls.
+        open_sub() calls.
         """
         q = Queue(self.backend, address="localhost", name=queue_name)
         if is_inst_name(self.backend, "rabbitmq.Backend"):  # HACK: manually set attr
@@ -400,7 +400,7 @@ class BackendUnitTest:
         class TestException(Exception):  # pylint: disable=C0115
             pass
 
-        async with q.recv() as gen:  # suppress_errors=True
+        async with q.open_sub() as gen:  # suppress_errors=True
             async for msg in gen:
                 logging.debug(msg)
                 raise TestException
@@ -411,7 +411,7 @@ class BackendUnitTest:
         logging.info("Round 2")
 
         # continue where we left off
-        async with q.recv() as gen:  # suppress_errors=True
+        async with q.open_sub() as gen:  # suppress_errors=True
             # self._get_mock_ack(mock_con).assert_not_called()
             async for i, msg in asl.enumerate(gen, start=1):
                 logging.debug(f"{i} :: {msg}")
@@ -428,7 +428,7 @@ class BackendUnitTest:
     async def test_queue_recv_12_comsumer_exception(
         self, mock_con: Any, queue_name: str
     ) -> None:
-        """Failure-test Queue.recv().
+        """Failure-test Queue.open_sub().
 
         Same as test_queue_recv_11_comsumer_exception() but with error
         propagation.
@@ -448,7 +448,7 @@ class BackendUnitTest:
 
         with pytest.raises(TestException):
             q.except_errors = False
-            async with q.recv() as gen:
+            async with q.open_sub() as gen:
                 async for msg in gen:
                     logging.debug(msg)
                     raise TestException
@@ -468,7 +468,7 @@ class BackendUnitTest:
 
         # continue where we left off
         q.except_errors = False
-        async with q.recv() as gen:
+        async with q.open_sub() as gen:
             self._get_ack_mock_fn(mock_con).assert_not_called()
             async for i, msg in asl.enumerate(gen, start=1):
                 logging.debug(f"{i} :: {msg}")

--- a/mqclient/abstract_backend_tests/utils.py
+++ b/mqclient/abstract_backend_tests/utils.py
@@ -10,7 +10,7 @@ from ..queue import Queue
 
 
 def is_inst_name(obj: Any, name: str) -> bool:
-    """Return the object's name, fully qualified with its module's name. """
+    """Return the object's name, fully qualified with its module's name."""
     obj_name = f"{obj.__class__.__module__}.{obj.__class__.__name__}"
 
     return obj_name == name or obj_name.endswith("." + name)

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -189,8 +189,8 @@ class Queue:
             "self.timeout",
         ]
     )
-    async def recv_one(self) -> AsyncIterator[Message]:
-        """Receive one message from the queue.
+    async def open_sub_one(self) -> AsyncIterator[Message]:
+        """Open a context to receive a single messages from the queue.
 
         This is an async context manager. If an exception is raised
         (inside the context), the message is rejected, the context is

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -231,15 +231,17 @@ class Queue:
             carrier="msg.headers",
             carrier_relation=wtt.CarrierRelation.LINK,
         )
-        def get_message_callback(msg: Optional[Message]) -> Optional[Message]:
+        def add_span_link(msg: Message) -> Message:
             return msg
 
         sub = await self._create_sub_queue()
-        msg = get_message_callback(await sub.get_message(self.timeout * 1000))
+        raw_msg = await sub.get_message(self.timeout * 1000)
 
-        if not msg:
+        if not raw_msg:  # no message -> close and exit
             await sub.close()
             return
+        else:  # got a message -> link and proceed
+            msg = add_span_link(raw_msg)
 
         try:
             yield msg.data

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -222,8 +222,11 @@ class Queue:
         Decorators:
             contextlib.asynccontextmanager
 
+        Raises:
+            EmptyQueueException -- if there is no available message
+
         Yields:
-            Any -- object of data received, or nothing if queue is empty
+            Any -- object of data received
         """
 
         @wtt.spanned(
@@ -239,7 +242,9 @@ class Queue:
 
         if not raw_msg:  # no message -> close and exit
             await sub.close()
-            return
+            raise EmptyQueueException(
+                "No message is available (`timeout` value may be too low)"
+            )
         else:  # got a message -> link and proceed
             msg = add_span_link(raw_msg)
 
@@ -265,6 +270,10 @@ class Queue:
             f"timeout={self.timeout}"
             f")"
         )
+
+
+class EmptyQueueException(Exception):
+    """Raised when the queue is empty."""
 
 
 class QueuePubResource:

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -155,18 +155,18 @@ class Queue:
         else:
             raise RuntimeError(f"Unrecognized AckStatus value: {msg}")
 
-    def recv(self) -> "MessageAsyncGeneratorContext":
-        """Receive a stream of messages from the queue.
+    def open_sub(self) -> "MessageAsyncGeneratorContext":
+        """Open a resource to receive messages from the queue as an iterator.
 
         This returns a context-manager/generator. Its iterator stops when no
         messages are received for `timeout` seconds. If an exception is raised
         (inside the context), the message is rejected, the context is exited,
         and exception can be re-raised if configured by `except_errors`.
-        Multiple calls to `recv()` is okay, but reusing the returned instance
-        is not.
+        Multiple calls to `open_sub()` is okay, but reusing the returned
+        instance is not.
 
         Example:
-            async with queue.recv() as stream:
+            async with queue.open_sub() as stream:
                 async for data in stream:
                     ...
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -88,8 +88,8 @@ class Queue:
             "self.timeout",
         ]
     )
-    async def sender(self) -> AsyncIterator["QueueSender"]:
-        """Send messages to the queue."""
+    async def open_pub(self) -> AsyncIterator["QueueSender"]:
+        """Open a resource to send messages to the queue."""
         pub = await self._create_pub_queue()
 
         try:

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -89,7 +89,22 @@ class Queue:
         ]
     )
     async def open_pub(self) -> AsyncIterator["QueuePubResource"]:
-        """Open a resource to send messages to the queue."""
+        """Open a resource to send messages to the queue.
+
+        This is an async context manager. An object is returned that can be
+        used to send n messages.
+
+        Example:
+            async with queue.open_pub() as p:
+                for msg in my_messages:
+                    await p.send(msg)
+
+        Decorators:
+            contextlib.asynccontextmanager
+
+        Returns:
+            QueuePubResource -- the object to invoke `.send()` on
+        """
         pub = await self._create_pub_queue()
 
         try:
@@ -167,8 +182,8 @@ class Queue:
 
         Example:
             async with queue.open_sub() as stream:
-                async for data in stream:
-                    ...
+                async for msg in stream:
+                    print(msg)
 
         NOTE: If using the GCP backend, a message is allocated for
         redelivery if the consumer's iteration takes longer than 10 minutes.
@@ -199,6 +214,10 @@ class Queue:
 
         NOTE: If using the GCP backend, a message is allocated for
         redelivery if the context is open for longer than 10 minutes.
+
+        Example:
+            async with q.open_sub_one() as msg:
+                print(msg)
 
         Decorators:
             contextlib.asynccontextmanager
@@ -246,6 +265,8 @@ class Queue:
 
 
 class QueuePubResource:
+    """A manager class around `Pub.send_message()`."""
+
     def __init__(self, pub: Pub):
         self.pub = pub
 

--- a/mqclient/queue.py
+++ b/mqclient/queue.py
@@ -88,12 +88,12 @@ class Queue:
             "self.timeout",
         ]
     )
-    async def open_pub(self) -> AsyncIterator["QueueSender"]:
+    async def open_pub(self) -> AsyncIterator["QueuePubResource"]:
         """Open a resource to send messages to the queue."""
         pub = await self._create_pub_queue()
 
         try:
-            yield QueueSender(pub)
+            yield QueuePubResource(pub)
         finally:
             await pub.close()
 
@@ -245,7 +245,7 @@ class Queue:
         )
 
 
-class QueueSender:
+class QueuePubResource:
     def __init__(self, pub: Pub):
         self.pub = pub
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -67,8 +67,8 @@ async def test_open_sub() -> None:
 
 
 @pytest.mark.asyncio
-async def test_recv_one() -> None:
-    """Test recv_one."""
+async def test_open_sub_one() -> None:
+    """Test open_sub_one."""
     mock_backend = AsyncMock()
     q = Queue(mock_backend)
 
@@ -76,7 +76,7 @@ async def test_recv_one() -> None:
     msg = Message(0, Message.serialize(data))
     mock_backend.create_sub_queue.return_value.get_message.return_value = msg
 
-    async with q.recv_one() as d:
+    async with q.open_sub_one() as d:
         recv_data = d
 
     assert data == recv_data

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -44,7 +44,7 @@ async def test_send() -> None:
 
 
 @pytest.mark.asyncio
-async def test_recv() -> None:
+async def test_open_sub() -> None:
     """Test recv."""
 
     # pylint:disable=unused-argument
@@ -58,7 +58,7 @@ async def test_recv() -> None:
     data = ["a", {"b": 100}, ["foo", "bar"]]
     mock_backend.create_sub_queue.return_value.message_generator = gen
 
-    async with q.recv() as recv_gen:
+    async with q.open_sub() as recv_gen:
         recv_data = [d async for d in recv_gen]
         assert data == recv_data
         recv_gen._sub.ack_message.assert_has_calls(
@@ -171,7 +171,7 @@ async def test_nack_previous() -> None:
     msgs = [Message(i, Message.serialize(d)) for i, d in enumerate(data)]
     mock_backend.create_sub_queue.return_value.message_generator = gen
 
-    async with q.recv() as recv_gen:
+    async with q.open_sub() as recv_gen:
         i = 0
         # manual nacking won't actually place the message for redelivery b/c of mocking
         async for _ in recv_gen:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -88,6 +88,22 @@ async def test_open_sub_one() -> None:
 
 
 @pytest.mark.asyncio
+async def test_open_sub_one__no_msg() -> None:
+    """Test open_sub_one with an empty queue."""
+    mock_backend = AsyncMock()
+    q = Queue(mock_backend)
+
+    mock_backend.create_sub_queue.return_value.get_message.return_value = None
+
+    async with q.open_sub_one() as _:
+        assert 0  # we should never get here
+
+    mock_backend.create_sub_queue.return_value.ack_message.assert_not_called()
+    mock_backend.create_sub_queue.return_value.reject_message.assert_not_called()
+    mock_backend.create_sub_queue.return_value.close.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_safe_ack() -> None:
     """Test _safe_ack()."""
     mock_backend = AsyncMock()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -31,7 +31,7 @@ async def test_send() -> None:
     q = Queue(mock_backend)
 
     data = {"a": 1234}
-    async with q.sender() as s:
+    async with q.open_pub() as s:
         await s.send(data)
     mock_backend.create_pub_queue.return_value.send_message.assert_awaited()
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -9,7 +9,7 @@ import pytest
 
 # local imports
 from mqclient.backend_interface import AckException, Backend, Message, NackException
-from mqclient.queue import Queue
+from mqclient.queue import EmptyQueueException, Queue
 
 
 def test_init() -> None:
@@ -95,8 +95,9 @@ async def test_open_sub_one__no_msg() -> None:
 
     mock_backend.create_sub_queue.return_value.get_message.return_value = None
 
-    async with q.open_sub_one() as _:
-        assert 0  # we should never get here
+    with pytest.raises(EmptyQueueException):
+        async with q.open_sub_one() as _:
+            assert 0  # we should never get here
 
     mock_backend.create_sub_queue.return_value.ack_message.assert_not_called()
     mock_backend.create_sub_queue.return_value.reject_message.assert_not_called()

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -34,6 +34,7 @@ async def test_send() -> None:
     async with q.open_pub() as s:
         await s.send(data)
     mock_backend.create_pub_queue.return_value.send_message.assert_awaited()
+    mock_backend.create_pub_queue.return_value.close.assert_called()
 
     # send() adds a unique header, so we need to look at only the data
     msg = Message(
@@ -65,6 +66,8 @@ async def test_open_sub() -> None:
             [call(Message(i, Message.serialize(d))) for i, d in enumerate(recv_data)]
         )
 
+    mock_backend.create_sub_queue.return_value.close.assert_called()
+
 
 @pytest.mark.asyncio
 async def test_open_sub_one() -> None:
@@ -81,6 +84,7 @@ async def test_open_sub_one() -> None:
 
     assert data == recv_data
     mock_backend.create_sub_queue.return_value.ack_message.assert_called_with(msg)
+    mock_backend.create_sub_queue.return_value.close.assert_called()
 
 
 @pytest.mark.asyncio
@@ -156,7 +160,7 @@ async def test_safe_nack() -> None:
 
 
 @pytest.mark.asyncio
-async def test_nack_previous() -> None:
+async def test_nack_current() -> None:
     """Test recv with nack_current()."""
 
     # pylint:disable=unused-argument


### PR DESCRIPTION
Newly named methods include: `open_pub()`, `open_sub()`, `open_sub_one()`

closes https://github.com/WIPACrepo/MQClient/issues/33